### PR TITLE
Metrics endpoint

### DIFF
--- a/HipercowApi/HipercowApi.csproj
+++ b/HipercowApi/HipercowApi.csproj
@@ -5,11 +5,17 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Hipercow_api</RootNamespace>
-	<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-	<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-	<Copyright>Imperial College London</Copyright>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Copyright>Imperial College London</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>HipercowApiUnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <Content Remove="stylecop.json" />

--- a/HipercowApi/Program.cs
+++ b/HipercowApi/Program.cs
@@ -3,6 +3,7 @@ namespace HipercowApi
 {
     using System.Diagnostics.CodeAnalysis;
     using HipercowApi.Tools;
+    using Prometheus;
 
     /// <summary>
     /// Hipercow_api main class.
@@ -30,6 +31,7 @@ namespace HipercowApi
             builder.Services.AddSingleton<IJobListQuery, JobListQuery>();
             builder.Services.AddSingleton<IClusterHandleCache, ClusterHandleCache>();
             builder.Services.AddSingleton<ISchedulerFactory, SchedulerFactory>();
+            builder.Services.AddHostedService<MetricsUpdateService>();
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.
@@ -42,8 +44,9 @@ namespace HipercowApi
             app.UseHttpsRedirection();
 
             app.UseAuthorization();
-
             app.MapControllers();
+
+            app.UseMetricServer();
 
             app.Run();
         }

--- a/HipercowApi/Tools/MetricsRegistry.cs
+++ b/HipercowApi/Tools/MetricsRegistry.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Imperial College London. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using Prometheus;
 
 /// <summary>
 /// Static registry of Hipercow metrics.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class MetricsRegistry
 {
     /// <summary>

--- a/HipercowApi/Tools/MetricsRegistry.cs
+++ b/HipercowApi/Tools/MetricsRegistry.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Imperial College London. All rights reserved.
+
+using Prometheus;
+
+/// <summary>
+/// Static registry of Hipercow metrics.
+/// </summary>
+public static class MetricsRegistry
+{
+    /// <summary>
+    /// Job count by cluster, user and state.
+    /// </summary>
+    public static readonly Gauge JobsGauge = Metrics.CreateGauge(
+        "jobs",
+        "Current jobs running by cluster, user and state.",
+        labelNames: ["cluster", "user", "state"]);
+
+    /// <summary>
+    /// Core hours used, by cluster and user.
+    /// </summary>
+    public static readonly Gauge CoreHoursGauge = Metrics.CreateGauge(
+        "core_hours",
+        "Core hours used by cluster and user.",
+        labelNames: ["cluster", "user"]);
+}

--- a/HipercowApi/Tools/MetricsUpdateService.cs
+++ b/HipercowApi/Tools/MetricsUpdateService.cs
@@ -4,6 +4,7 @@ namespace HipercowApi.Tools
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Hpc.Scheduler;
     using Microsoft.Hpc.Scheduler.Properties;
@@ -20,6 +21,11 @@ namespace HipercowApi.Tools
     public class MetricsUpdateService(
         IClusterHandleCache clusterHandleCache) : BackgroundService
     {
+        private static readonly List<string> InterestingStates = new()
+        {
+            "Running", "Queued", "Finished", "Failed", "Cancelled",
+        };
+
         private readonly IClusterHandleCache clusterHandleCache = clusterHandleCache;
         private readonly Dictionary<string, Dictionary<string, dynamic>> userJobs = [];
 
@@ -37,15 +43,13 @@ namespace HipercowApi.Tools
         {
             var start = (DateTime)job[JobPropertyIds.StartTime].Value;
             var end = (state == JobState.Finished) ?
-                (DateTime)job[JobPropertyIds.EndTime].Value :
-                DateTime.Now;
-            var unitType = (JobUnitType)job[JobPropertyIds.UnitType].Value;
-            var unitCount = (unitType == JobUnitType.Core) ?
-                (int)job[JobPropertyIds.MinCores].Value :
-                (int)job[JobPropertyIds.MinNodes].Value;
-            var noCores = (unitType == JobUnitType.Core) ?
-                unitCount :
-                unitCount * 32;
+                        (DateTime)job[JobPropertyIds.EndTime].Value :
+                         DateTime.Now;
+
+            var useCores = (JobUnitType)job[JobPropertyIds.UnitType].Value == JobUnitType.Core;
+            var unitCount = (int)job[useCores ? JobPropertyIds.MinCores : JobPropertyIds.MinNodes].Value;
+
+            var noCores = useCores ? unitCount : unitCount * 32;
             TimeSpan span = end - start;
             return (float)span.TotalHours * noCores;
         }
@@ -59,7 +63,7 @@ namespace HipercowApi.Tools
         {
             return this.userJobs;
         }
-        
+
         /// <summary>
         /// Query a cluster and update the userJobs records, which store
         /// for each user, how many jobs they have (in recent history), in
@@ -115,22 +119,32 @@ namespace HipercowApi.Tools
                 this.userJobs.TryGetValue(user, out Dictionary<string, dynamic>? value);
                 if (value is null)
                 {
-                    value = [];
-                    value["Finished"] = 0;
-                    value["Queued"] = 0;
-                    value["Cancelled"] = 0;
-                    value["Running"] = 0;
-                    value["Failed"] = 0;
+                    value = InterestingStates.ToDictionary(state => state, _ => (dynamic)0);
                     value["coreHours"] = 0.0f;
                     this.userJobs.Add(user, value);
                 }
 
                 value[stateName]++;
-                if ((state == JobState.Finished) || (state == JobState.Running))
+                if (state is JobState.Finished or JobState.Running)
                 {
                     value["coreHours"] += GetCoreHours(job, state);
                 }
             }
+        }
+
+        /// <summary>
+        /// Update all the metrics we're interested in, for a cluster.
+        /// </summary>
+        /// <param name="cluster">Name of cluster.</param>
+        // Excluding from code coverage as I test UpdateByState separately.
+        [ExcludeFromCodeCoverage]
+        internal void UpdateAllMetrics(string cluster)
+        {
+            this.UpdateByState(cluster, JobState.Running, int.MaxValue);
+            this.UpdateByState(cluster, JobState.Queued, int.MaxValue);
+            this.UpdateByState(cluster, JobState.Finished, 24);
+            this.UpdateByState(cluster, JobState.Failed, 24);
+            this.UpdateByState(cluster, JobState.Canceled, 24);
         }
 
         /// <summary>
@@ -149,19 +163,12 @@ namespace HipercowApi.Tools
                 foreach (var cluster in clusters)
                 {
                     this.userJobs.Clear();
-                    this.UpdateByState(cluster, JobState.Running, int.MaxValue);
-                    this.UpdateByState(cluster, JobState.Queued, int.MaxValue);
-                    this.UpdateByState(cluster, JobState.Finished, 24);
-                    this.UpdateByState(cluster, JobState.Failed, 24);
-                    this.UpdateByState(cluster, JobState.Canceled, 24);
+                    this.UpdateAllMetrics(cluster);
 
                     foreach (var user in this.userJobs.Keys)
                     {
                         var details = this.userJobs[user];
-                        foreach (string state in new List<string>
-                        {
-                            "Running", "Queued", "Finished", "Failed", "Cancelled",
-                        })
+                        foreach (string state in InterestingStates)
                         {
                             MetricsRegistry.JobsGauge.
                                 WithLabels([cluster, user, state]).

--- a/HipercowApi/Tools/MetricsUpdateService.cs
+++ b/HipercowApi/Tools/MetricsUpdateService.cs
@@ -3,85 +3,81 @@
 namespace HipercowApi.Tools
 {
     using System;
-    using System.Runtime.CompilerServices;
-    using System.Security.Cryptography.X509Certificates;
+    using System.Diagnostics.CodeAnalysis;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Hpc.Scheduler;
     using Microsoft.Hpc.Scheduler.Properties;
-    using Prometheus;
 
     /// <summary>
     /// The implementation of IMetrics.
     /// </summary>
-    public class MetricsUpdateService : BackgroundService
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="MetricsUpdateService"/> class.
+    /// </remarks>
+    /// <param name="clusterHandleCache">
+    /// Handle cache so we can query the headnode.
+    /// </param>
+    public class MetricsUpdateService(IClusterHandleCache clusterHandleCache) : BackgroundService
     {
-        private readonly IClusterHandleCache clusterHandleCache;
-        private Dictionary<string, Dictionary<string, dynamic>> userJobs = [];
+        private readonly IClusterHandleCache clusterHandleCache = clusterHandleCache;
+        private readonly Dictionary<string, Dictionary<string, dynamic>> userJobs = [];
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MetricsUpdateService"/> class.
+        /// Return user jobs for testing.
         /// </summary>
-        /// <param name="clusterHandleCache">
-        /// Handle cache so we can query the headnode.
-        /// </param>
-        public MetricsUpdateService(IClusterHandleCache clusterHandleCache)
+        /// <returns>The userJobs structure.
+        /// </returns>
+        internal Dictionary<string, Dictionary<string, dynamic>> GetUserJobs()
         {
-            this.clusterHandleCache = clusterHandleCache;
+            return this.userJobs;
         }
 
         /// <summary>
-        /// The async task to periodically update the metrics.
+        /// Calculate core hours for a Finished or Running job.
         /// </summary>
-        /// <param name="stoppingToken">
-        /// Token for aborting the periodic updates when shutting down.</param>
-        /// <returns>I am not sure.</returns>
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                List<string> clusters = DideConstants.GetDideClusters();
-                foreach (var cluster in clusters)
-                {
-                    this.userJobs.Clear();
-                    this.UpdateByState(cluster, JobState.Running, int.MaxValue);
-                    this.UpdateByState(cluster, JobState.Queued, int.MaxValue);
-                    this.UpdateByState(cluster, JobState.Finished, 24);
-                    this.UpdateByState(cluster, JobState.Failed, 24);
-                    this.UpdateByState(cluster, JobState.Canceled, 24);
-
-                    foreach (var user in this.userJobs.Keys)
-                    {
-                        var details = this.userJobs[user];
-                        foreach (string state in new List<string> { "Running", "Queued", "Finished", "Failed", "Cancelled" })
-                        {
-                            MetricsRegistry.JobsGauge.WithLabels([cluster, user, state]).Set(details[state]);
-                        }
-
-                        MetricsRegistry.CoreHoursGauge.WithLabels([cluster, user]).Set(details["coreHours"]);
-                    }
-                }
-
-                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
-            }
-        }
-
-        private static float GetCoreHours(PropertyRow job, JobState state)
+        /// <param name="job">PropertyRow for the job, returned from the
+        /// ISchedulerJobEnumerator.</param>
+        /// <param name="state">HPC JobState for the job.
+        /// Since I deal with states separately, I don't query this back
+        /// from the cluster, so it's not in the job property, to keep that
+        /// query as light as possible. Perhaps pedantic.</param>
+        /// <returns>The number of core hours, as a float.</returns>
+        internal static float GetCoreHours(PropertyRow job, JobState state)
         {
             var start = (DateTime)job[JobPropertyIds.StartTime].Value;
-            var end = (state == JobState.Finished) ? (DateTime)job[JobPropertyIds.EndTime].Value : DateTime.Now;
+            var end = (state == JobState.Finished) ?
+                (DateTime)job[JobPropertyIds.EndTime].Value :
+                DateTime.Now;
             var unitType = (JobUnitType)job[JobPropertyIds.UnitType].Value;
-            var unitCount = (int)job[JobPropertyIds.MinCores].Value;
-            var noCores = (unitType == JobUnitType.Core) ? unitCount : unitCount * 32;
+            var unitCount = (unitType == JobUnitType.Core) ?
+                (int)job[JobPropertyIds.MinCores].Value :
+                (int)job[JobPropertyIds.MinNodes].Value;
+            var noCores = (unitType == JobUnitType.Core) ?
+                unitCount :
+                unitCount * 32;
             TimeSpan span = end - start;
             return (float)span.TotalHours * noCores;
         }
 
-        private void UpdateByState(string cluster, JobState state, int maxHoursAgo)
+        /// <summary>
+        /// Query a cluster and update the userJobs records, which store
+        /// for each user, how many jobs they have (in recent history), in
+        /// a particular state, and also how many core-hours they have
+        /// consumed. I made this state-specific as there will be different
+        /// maxHoursAgo settings for different states, and the querying can
+        /// be made quicker if it is state specific.
+        /// </summary>
+        /// <param name="cluster">Name of the headnode to query.</param>
+        /// <param name="state">Include only jobs in this state.</param>
+        /// <param name="maxHoursAgo">Include only jobs whose status
+        /// changed within this window.</param>
+        internal void UpdateByState(string cluster, JobState state, int maxHoursAgo)
         {
             IScheduler scheduler = this.clusterHandleCache.GetClusterHandle(cluster)!;
 
-            PropertyIdCollection props = [JobPropertyIds.Id, JobPropertyIds.UserName, JobPropertyIds.Owner, JobPropertyIds.ChangeTime,
-            JobPropertyIds.StartTime, JobPropertyIds.EndTime, JobPropertyIds.MinCores, JobPropertyIds.UnitType];
+            PropertyIdCollection props = [JobPropertyIds.UserName, JobPropertyIds.Owner, JobPropertyIds.ChangeTime,
+                  JobPropertyIds.StartTime, JobPropertyIds.EndTime, JobPropertyIds.MinCores, JobPropertyIds.MinNodes,
+                  JobPropertyIds.UnitType];
 
             IFilterCollection jobFilter = scheduler.CreateFilterCollection();
             jobFilter.Add(FilterOperator.Equal, JobPropertyIds.State, state);
@@ -96,7 +92,9 @@ namespace HipercowApi.Tools
             ISchedulerRowEnumerator jobs = scheduler.OpenJobEnumerator(props, jobFilter, sortFilter);
             var now = DateTime.Now;
             var stateName = (state == JobState.Canceled) ? "Cancelled" : Enum.GetName(state)!;
-            foreach (var job in jobs)
+            var jobList = jobs.GetRows(int.MaxValue);
+
+            foreach (var job in jobList.Rows)
             {
                 var changeTime = job[JobPropertyIds.ChangeTime];
                 TimeSpan diff = now - (DateTime)changeTime.Value;
@@ -129,6 +127,44 @@ namespace HipercowApi.Tools
                 {
                     value["coreHours"] += GetCoreHours(job, state);
                 }
+            }
+        }
+
+        /// <summary>
+        /// The async task to periodically update the metrics.
+        /// </summary>
+        /// <param name="stoppingToken">
+        /// Token for aborting the periodic updates.</param>
+        /// <returns>An async task.</returns>
+        // Unsure how to test this function - will test others...
+        [ExcludeFromCodeCoverage]
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                List<string> clusters = DideConstants.GetDideClusters();
+                foreach (var cluster in clusters)
+                {
+                    this.userJobs.Clear();
+                    this.UpdateByState(cluster, JobState.Running, int.MaxValue);
+                    this.UpdateByState(cluster, JobState.Queued, int.MaxValue);
+                    this.UpdateByState(cluster, JobState.Finished, 24);
+                    this.UpdateByState(cluster, JobState.Failed, 24);
+                    this.UpdateByState(cluster, JobState.Canceled, 24);
+
+                    foreach (var user in this.userJobs.Keys)
+                    {
+                        var details = this.userJobs[user];
+                        foreach (string state in new List<string> { "Running", "Queued", "Finished", "Failed", "Cancelled" })
+                        {
+                            MetricsRegistry.JobsGauge.WithLabels([cluster, user, state]).Set(details[state]);
+                        }
+
+                        MetricsRegistry.CoreHoursGauge.WithLabels([cluster, user]).Set(details["coreHours"]);
+                    }
+                }
+
+                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
             }
         }
     }

--- a/HipercowApi/Tools/MetricsUpdateService.cs
+++ b/HipercowApi/Tools/MetricsUpdateService.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Imperial College London. All rights reserved.
+
+namespace HipercowApi.Tools
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Security.Cryptography.X509Certificates;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Hpc.Scheduler;
+    using Microsoft.Hpc.Scheduler.Properties;
+    using Prometheus;
+
+    /// <summary>
+    /// The implementation of IMetrics.
+    /// </summary>
+    public class MetricsUpdateService : BackgroundService
+    {
+        private readonly IClusterHandleCache clusterHandleCache;
+        private Dictionary<string, Dictionary<string, dynamic>> userJobs = [];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MetricsUpdateService"/> class.
+        /// </summary>
+        /// <param name="clusterHandleCache">
+        /// Handle cache so we can query the headnode.
+        /// </param>
+        public MetricsUpdateService(IClusterHandleCache clusterHandleCache)
+        {
+            this.clusterHandleCache = clusterHandleCache;
+        }
+
+        /// <summary>
+        /// The async task to periodically update the metrics.
+        /// </summary>
+        /// <param name="stoppingToken">
+        /// Token for aborting the periodic updates when shutting down.</param>
+        /// <returns>I am not sure.</returns>
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                List<string> clusters = DideConstants.GetDideClusters();
+                foreach (var cluster in clusters)
+                {
+                    this.userJobs.Clear();
+                    this.UpdateByState(cluster, JobState.Running, int.MaxValue);
+                    this.UpdateByState(cluster, JobState.Queued, int.MaxValue);
+                    this.UpdateByState(cluster, JobState.Finished, 24);
+                    this.UpdateByState(cluster, JobState.Failed, 24);
+                    this.UpdateByState(cluster, JobState.Canceled, 24);
+
+                    foreach (var user in this.userJobs.Keys)
+                    {
+                        var details = this.userJobs[user];
+                        foreach (string state in new List<string> { "Running", "Queued", "Finished", "Failed", "Cancelled" })
+                        {
+                            MetricsRegistry.JobsGauge.WithLabels([cluster, user, state]).Set(details[state]);
+                        }
+
+                        MetricsRegistry.CoreHoursGauge.WithLabels([cluster, user]).Set(details["coreHours"]);
+                    }
+                }
+
+                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+            }
+        }
+
+        private static float GetCoreHours(PropertyRow job, JobState state)
+        {
+            var start = (DateTime)job[JobPropertyIds.StartTime].Value;
+            var end = (state == JobState.Finished) ? (DateTime)job[JobPropertyIds.EndTime].Value : DateTime.Now;
+            var unitType = (JobUnitType)job[JobPropertyIds.UnitType].Value;
+            var unitCount = (int)job[JobPropertyIds.MinCores].Value;
+            var noCores = (unitType == JobUnitType.Core) ? unitCount : unitCount * 32;
+            TimeSpan span = end - start;
+            return (float)span.TotalHours * noCores;
+        }
+
+        private void UpdateByState(string cluster, JobState state, int maxHoursAgo)
+        {
+            IScheduler scheduler = this.clusterHandleCache.GetClusterHandle(cluster)!;
+
+            PropertyIdCollection props = [JobPropertyIds.Id, JobPropertyIds.UserName, JobPropertyIds.Owner, JobPropertyIds.ChangeTime,
+            JobPropertyIds.StartTime, JobPropertyIds.EndTime, JobPropertyIds.MinCores, JobPropertyIds.UnitType];
+
+            IFilterCollection jobFilter = scheduler.CreateFilterCollection();
+            jobFilter.Add(FilterOperator.Equal, JobPropertyIds.State, state);
+            ISortCollection sortFilter = new SortCollection
+            {
+                {
+                    SortProperty.SortOrder.Descending,
+                    JobPropertyIds.ChangeTime
+                },
+            };
+
+            ISchedulerRowEnumerator jobs = scheduler.OpenJobEnumerator(props, jobFilter, sortFilter);
+            var now = DateTime.Now;
+            var stateName = (state == JobState.Canceled) ? "Cancelled" : Enum.GetName(state)!;
+            foreach (var job in jobs)
+            {
+                var changeTime = job[JobPropertyIds.ChangeTime];
+                TimeSpan diff = now - (DateTime)changeTime.Value;
+
+                if (diff.TotalHours >= maxHoursAgo)
+                {
+                    break;
+                }
+
+                string user = Utils.HPCString(job[JobPropertyIds.UserName]);
+                string owner = Utils.HPCString(job[JobPropertyIds.Owner]);
+                user = (user.Trim() == string.Empty) ? owner : user;
+                user = user.Replace("DIDE\\", string.Empty);
+
+                this.userJobs.TryGetValue(user, out Dictionary<string, dynamic>? value);
+                if (value is null)
+                {
+                    value = [];
+                    value["Finished"] = 0;
+                    value["Queued"] = 0;
+                    value["Cancelled"] = 0;
+                    value["Running"] = 0;
+                    value["Failed"] = 0;
+                    value["coreHours"] = 0.0f;
+                    this.userJobs.Add(user, value);
+                }
+
+                value[stateName]++;
+                if ((state == JobState.Finished) || (state == JobState.Running))
+                {
+                    value["coreHours"] += GetCoreHours(job, state);
+                }
+            }
+        }
+    }
+}

--- a/HipercowApi/Tools/MetricsUpdateService.cs
+++ b/HipercowApi/Tools/MetricsUpdateService.cs
@@ -17,20 +17,11 @@ namespace HipercowApi.Tools
     /// <param name="clusterHandleCache">
     /// Handle cache so we can query the headnode.
     /// </param>
-    public class MetricsUpdateService(IClusterHandleCache clusterHandleCache) : BackgroundService
+    public class MetricsUpdateService(
+        IClusterHandleCache clusterHandleCache) : BackgroundService
     {
         private readonly IClusterHandleCache clusterHandleCache = clusterHandleCache;
         private readonly Dictionary<string, Dictionary<string, dynamic>> userJobs = [];
-
-        /// <summary>
-        /// Return user jobs for testing.
-        /// </summary>
-        /// <returns>The userJobs structure.
-        /// </returns>
-        internal Dictionary<string, Dictionary<string, dynamic>> GetUserJobs()
-        {
-            return this.userJobs;
-        }
 
         /// <summary>
         /// Calculate core hours for a Finished or Running job.
@@ -60,6 +51,16 @@ namespace HipercowApi.Tools
         }
 
         /// <summary>
+        /// Return user jobs for testing.
+        /// </summary>
+        /// <returns>The userJobs structure.
+        /// </returns>
+        internal Dictionary<string, Dictionary<string, dynamic>> GetUserJobs()
+        {
+            return this.userJobs;
+        }
+        
+        /// <summary>
         /// Query a cluster and update the userJobs records, which store
         /// for each user, how many jobs they have (in recent history), in
         /// a particular state, and also how many core-hours they have
@@ -75,9 +76,10 @@ namespace HipercowApi.Tools
         {
             IScheduler scheduler = this.clusterHandleCache.GetClusterHandle(cluster)!;
 
-            PropertyIdCollection props = [JobPropertyIds.UserName, JobPropertyIds.Owner, JobPropertyIds.ChangeTime,
-                  JobPropertyIds.StartTime, JobPropertyIds.EndTime, JobPropertyIds.MinCores, JobPropertyIds.MinNodes,
-                  JobPropertyIds.UnitType];
+            PropertyIdCollection props = [
+                JobPropertyIds.UserName, JobPropertyIds.Owner, JobPropertyIds.ChangeTime,
+                JobPropertyIds.StartTime, JobPropertyIds.EndTime, JobPropertyIds.MinCores,
+                JobPropertyIds.MinNodes, JobPropertyIds.UnitType];
 
             IFilterCollection jobFilter = scheduler.CreateFilterCollection();
             jobFilter.Add(FilterOperator.Equal, JobPropertyIds.State, state);
@@ -89,7 +91,8 @@ namespace HipercowApi.Tools
                 },
             };
 
-            ISchedulerRowEnumerator jobs = scheduler.OpenJobEnumerator(props, jobFilter, sortFilter);
+            ISchedulerRowEnumerator jobs = scheduler.OpenJobEnumerator(
+                props, jobFilter, sortFilter);
             var now = DateTime.Now;
             var stateName = (state == JobState.Canceled) ? "Cancelled" : Enum.GetName(state)!;
             var jobList = jobs.GetRows(int.MaxValue);
@@ -155,12 +158,18 @@ namespace HipercowApi.Tools
                     foreach (var user in this.userJobs.Keys)
                     {
                         var details = this.userJobs[user];
-                        foreach (string state in new List<string> { "Running", "Queued", "Finished", "Failed", "Cancelled" })
+                        foreach (string state in new List<string> {
+                            "Running", "Queued", "Finished", "Failed", "Cancelled",
+                        })
                         {
-                            MetricsRegistry.JobsGauge.WithLabels([cluster, user, state]).Set(details[state]);
+                            MetricsRegistry.JobsGauge.
+                                WithLabels([cluster, user, state]).
+                                Set(details[state]);
                         }
 
-                        MetricsRegistry.CoreHoursGauge.WithLabels([cluster, user]).Set(details["coreHours"]);
+                        MetricsRegistry.CoreHoursGauge.
+                            WithLabels([cluster, user]).
+                            Set(details["coreHours"]);
                     }
                 }
 

--- a/HipercowApi/Tools/MetricsUpdateService.cs
+++ b/HipercowApi/Tools/MetricsUpdateService.cs
@@ -158,7 +158,8 @@ namespace HipercowApi.Tools
                     foreach (var user in this.userJobs.Keys)
                     {
                         var details = this.userJobs[user];
-                        foreach (string state in new List<string> {
+                        foreach (string state in new List<string>
+                        {
                             "Running", "Queued", "Finished", "Failed", "Cancelled",
                         })
                         {
@@ -173,7 +174,7 @@ namespace HipercowApi.Tools
                     }
                 }
 
-                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+                await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
             }
         }
     }

--- a/HipercowApiUnitTests/Tools/MetricsUpdateServiceTests.cs
+++ b/HipercowApiUnitTests/Tools/MetricsUpdateServiceTests.cs
@@ -2,6 +2,7 @@
 
 namespace HipercowApiUnitTests.Tools
 {
+    using System.Diagnostics.CodeAnalysis;
     using HipercowApi.Tools;
     using Microsoft.Hpc.Scheduler;
     using Microsoft.Hpc.Scheduler.Properties;
@@ -63,9 +64,11 @@ namespace HipercowApiUnitTests.Tools
         }
 
         /// <summary>
-        /// Test metrics update call.
+        /// Test metrics update call. I get strange partial code coverage
+        /// on the Assert.Equal lines - not sure why.
         /// </summary>
         [Fact]
+        [ExcludeFromCodeCoverage]
         public void MetricsUpdate_Works()
         {
             var mockScheduler = new Mock<IScheduler>();
@@ -87,6 +90,7 @@ namespace HipercowApiUnitTests.Tools
 
             mus.UpdateByState("potato", JobState.Finished, 24);
             var res = mus.GetUserJobs();
+
             Assert.Equal(1, res["A"]["Finished"]);
             Assert.Equal(2, res["A"]["coreHours"]);
             Assert.Equal(1, res["B"]["Finished"]);

--- a/HipercowApiUnitTests/Tools/MetricsUpdateServiceTests.cs
+++ b/HipercowApiUnitTests/Tools/MetricsUpdateServiceTests.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Imperial College London. All rights reserved.
+
+namespace HipercowApiUnitTests.Tools
+{
+    using HipercowApi.Tools;
+    using Microsoft.Hpc.Scheduler;
+    using Microsoft.Hpc.Scheduler.Properties;
+    using Moq;
+
+    /// <summary>
+    /// Tests on the unit class.
+    /// </summary>
+    public class MetricsUpdateServiceTests
+    {
+        /// <summary>
+        /// GetCoreHours works for a multi-core single node job.
+        /// </summary>
+        [Fact]
+        public void GetCoreHoursCores_Works()
+        {
+            DateTime end = new(2025, 5, 1, 12, 0, 0);
+            DateTime start = end.AddHours(-1);
+            PropertyRow p = new([
+                    new StoreProperty(JobPropertyIds.StartTime, start),
+                    new StoreProperty(JobPropertyIds.EndTime, end),
+                    new StoreProperty(JobPropertyIds.UnitType, JobUnitType.Core),
+                    new StoreProperty(JobPropertyIds.MinCores, 2)]);
+
+            Assert.Equal(2, MetricsUpdateService.GetCoreHours(p, JobState.Finished));
+        }
+
+        /// <summary>
+        /// GetCoreHours works for a multi-node node job. (Assuming 32-cores per node).
+        /// </summary>
+        [Fact]
+        public void GetCoreHoursNodes_Works()
+        {
+            DateTime end = new(2025, 5, 1, 12, 0, 0);
+            DateTime start = end.AddHours(-1);
+            PropertyRow p = new([
+                    new StoreProperty(JobPropertyIds.StartTime, start),
+                    new StoreProperty(JobPropertyIds.EndTime, end),
+                    new StoreProperty(JobPropertyIds.UnitType, JobUnitType.Node),
+                    new StoreProperty(JobPropertyIds.MinNodes, 3)]);
+
+            Assert.Equal(96, MetricsUpdateService.GetCoreHours(p, JobState.Finished));
+        }
+
+        /// <summary>
+        /// GetCoreHours works for a still-running job.
+        /// </summary>
+        [Fact]
+        public void GetCoreHoursRunning_Works()
+        {
+            DateTime start = DateTime.Now.AddHours(-1.5);
+            PropertyRow p = new([
+                    new StoreProperty(JobPropertyIds.StartTime, start),
+                    new StoreProperty(JobPropertyIds.UnitType, JobUnitType.Core),
+                    new StoreProperty(JobPropertyIds.MinCores, 5)]);
+            float corehours = MetricsUpdateService.GetCoreHours(p, JobState.Running);
+            Assert.True(corehours > 1.4 * 5);
+            Assert.True(corehours < 1.6 * 5);
+        }
+
+        /// <summary>
+        /// Test metrics update call.
+        /// </summary>
+        [Fact]
+        public void MetricsUpdate_Works()
+        {
+            var mockScheduler = new Mock<IScheduler>();
+            mockScheduler.Setup(x => x.Connect("potato")).Verifiable();
+            var mockRowEnumerator = new Mock<ISchedulerRowEnumerator>();
+            mockScheduler.Setup(x => x.OpenJobEnumerator(
+                It.IsAny<PropertyIdCollection>(),
+                It.IsAny<IFilterCollection>(),
+                It.IsAny<SortCollection>())).Returns(mockRowEnumerator.Object);
+            mockScheduler.Setup(x => x.CreateFilterCollection()).Returns(new FilterCollection());
+            mockRowEnumerator.Setup(x => x.GetRows(It.IsAny<int>())).
+                Returns(new PropertyRowSet(null, AllJobs()));
+
+            var mockCHC = new Mock<IClusterHandleCache>();
+            mockCHC.Setup(x => x.GetClusterHandle(It.IsAny<string>())).Returns(mockScheduler.Object);
+            MetricsUpdateService mus = new(mockCHC.Object);
+
+            mus.UpdateByState("potato", JobState.Finished, 24);
+            var res = mus.GetUserJobs();
+            Assert.Equal(1, res["A"]["Finished"]);
+            Assert.Equal(2, res["A"]["coreHours"]);
+            Assert.Equal(1, res["B"]["Finished"]);
+            Assert.Equal(2, res["B"]["coreHours"]);
+            Assert.Equal(1, res["C"]["Finished"]);
+            Assert.Equal(64, res["C"]["coreHours"]);
+            Assert.False(res.ContainsKey("D"));
+
+            mus.UpdateByState("potato", JobState.Canceled, 24);
+            res = mus.GetUserJobs();
+            Assert.False(res["A"].ContainsKey("Canceled"));
+            Assert.True(res["A"].ContainsKey("Cancelled"));
+
+            mus.UpdateByState("potato", JobState.Running, 24);
+            Thread.Sleep(10);
+            res = mus.GetUserJobs();
+            float corehours = res["A"]["coreHours"];
+            Assert.True(corehours > 6);
+        }
+
+        private static PropertyRow FakeJobInfo(
+             string user,
+             string owner,
+             DateTime changeTime,
+             DateTime startTime,
+             DateTime endTime,
+             int minCores,
+             int minNodes,
+             JobUnitType unitType)
+        {
+            return new PropertyRow([
+                    new StoreProperty(JobPropertyIds.UserName, user),
+                    new StoreProperty(JobPropertyIds.Owner, owner),
+                    new StoreProperty(JobPropertyIds.ChangeTime, changeTime),
+                    new StoreProperty(JobPropertyIds.StartTime, startTime),
+                    new StoreProperty(JobPropertyIds.EndTime, endTime),
+                    new StoreProperty(JobPropertyIds.MinCores, minCores),
+                    new StoreProperty(JobPropertyIds.MinNodes, minNodes),
+                    new StoreProperty(JobPropertyIds.UnitType, unitType)]);
+        }
+
+        private static PropertyRow[] AllJobs()
+        {
+            DateTime t1 = DateTime.Now.AddHours(-2);
+            DateTime t2 = DateTime.Now.AddHours(-1);
+            DateTime dtnew = DateTime.Now.AddHours(-0.5);
+            DateTime dtold = DateTime.Now.AddDays(-30);
+
+            return [
+                FakeJobInfo("A", "A", dtnew, t1, t2, 2, 0, JobUnitType.Core),
+                FakeJobInfo(string.Empty, "B", dtnew, t1, t2, 2, 0, JobUnitType.Core),
+                FakeJobInfo("C", "C", dtnew, t1, t2, 0, 2, JobUnitType.Node),
+                FakeJobInfo("D", "D", dtold, t1, t2, 0, 2, JobUnitType.Node)
+            ];
+        }
+    }
+}

--- a/HipercowApiUnitTests/Tools/MetricsUpdateServiceTests.cs
+++ b/HipercowApiUnitTests/Tools/MetricsUpdateServiceTests.cs
@@ -75,12 +75,14 @@ namespace HipercowApiUnitTests.Tools
                 It.IsAny<PropertyIdCollection>(),
                 It.IsAny<IFilterCollection>(),
                 It.IsAny<SortCollection>())).Returns(mockRowEnumerator.Object);
-            mockScheduler.Setup(x => x.CreateFilterCollection()).Returns(new FilterCollection());
+            mockScheduler.Setup(x => x.CreateFilterCollection()).
+                Returns(new FilterCollection());
             mockRowEnumerator.Setup(x => x.GetRows(It.IsAny<int>())).
                 Returns(new PropertyRowSet(null, AllJobs()));
 
             var mockCHC = new Mock<IClusterHandleCache>();
-            mockCHC.Setup(x => x.GetClusterHandle(It.IsAny<string>())).Returns(mockScheduler.Object);
+            mockCHC.Setup(x => x.GetClusterHandle(It.IsAny<string>())).
+                Returns(mockScheduler.Object);
             MetricsUpdateService mus = new(mockCHC.Object);
 
             mus.UpdateByState("potato", JobState.Finished, 24);

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ This is the .NET Core Web api to talk to our MS HPC Cluster.
 * `/api/v1/Clusters/{cluster}` - Cluster name, maxRam, maxCores, nodes list, queues list and defaultQueue.
 * `/api/v1/ClusterLoad/{cluster}` - Cluster name, list of nodeLoads - each of which is name, coresInUse, nodeCores and state.
 * `/api/v1/JobList` - POST cluster, user, state and maxRows to query jobs the headnode knows about with those filters.
+* `/metrics`- Endpoint for Prometheus.
 


### PR DESCRIPTION
SO - this one..

* adds the prometheus-net package (actually I think this might already have been there...)
* The MetricsRegistry static class will store the gauges and counters I'm going to maintain.
* The MetricsUpdateService class is where it happens - ExecuteAsync is a background task that will get periodically called (daily I think) - it calls a bunch of updates to fetch data from the cluster (UpdateByState) - I accumulate some stats in the userJobs dictionary, and then send those out to a couple of gauges.
* This gets served on localhost/metrics if I added the lines in Program.cs

All subject to change in terms of exactly what I export and when, but hopefully this looks ok for the basic layout.